### PR TITLE
Remove Sketch generator comments from SVG icons

### DIFF
--- a/linkedin.svg
+++ b/linkedin.svg
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="55px" height="55px" viewBox="0 0 55 55" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
-    <!-- Generator: Sketch 3.3.2 (12043) - http://www.bohemiancoding.com/sketch -->
     <title>Linked in</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>

--- a/octocat.svg
+++ b/octocat.svg
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="54px" height="55px" viewBox="0 0 54 55" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
-    <!-- Generator: Sketch 3.3.2 (12043) - http://www.bohemiancoding.com/sketch -->
     <title>octocat</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>

--- a/twitter.svg
+++ b/twitter.svg
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="53px" height="54px" viewBox="0 0 53 54" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
-    <!-- Generator: Sketch 3.3.2 (12043) - http://www.bohemiancoding.com/sketch -->
     <title>twitter</title>
     <desc>Created with Sketch.</desc>
     <defs></defs>


### PR DESCRIPTION
## Summary
- remove Sketch generator comments from svg icons

## Testing
- `npm test` (fails: ENOENT no such file or directory, open 'package.json')

------
https://chatgpt.com/codex/tasks/task_e_68a0f692ac488330b86fd1bf6d252758